### PR TITLE
Change menu border width

### DIFF
--- a/spigotmc-newdark-userstyle.css
+++ b/spigotmc-newdark-userstyle.css
@@ -89,7 +89,7 @@
         color: #ddd;
     }
     .Menu {
-        border-width: 2px;
+        border-width: 1px;
         border-left-color: #444;
         border-right-color: #444;
         border-bottom-color: #444;


### PR DESCRIPTION
Spigot also uses 1px width, I think it looks better but if you have a reason why it's 2px it can stay like that.